### PR TITLE
Update Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,7 +27,7 @@ Vagrant.configure("2") do |config|
     controller.vm.provision 'shell', inline: "fallocate -l 1G /swapfile && chmod 600 /swapfile && mkswap /swapfile && swapon /swapfile"
     controller.vm.provision 'shell', inline: "echo '/swapfile  swap swap  sw  0  0 '>> /etc/fstab"
     controller.vm.provision 'shell', inline: "sudo snap install microstack --classic --beta"
-    controller.vm.provision 'shell', inline: "sudo microstack.init --auto"
+    controller.vm.provision 'shell', inline: "sudo microstack.init --auto --control"
   end
 
 


### PR DESCRIPTION
Add flag --control or --compute to microstack.init call (throws an error without this flag (tested with Vagrant version 2.3.2)
I received an error about this missing flag on my run and thought I'd open a PR.